### PR TITLE
Switch to the C/R engine Warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,10 @@ kubectl logs --tail 100 -l app="$SRVC_NAME-crac-s3-cli"
 The results for the implementation that is based on the general approach provided by CRaC are as follows:
 Deployment | Checkpoint files size (MB) | Image size on ECR (MB) | Time to download Checkpoint files (Seconds) | Startup time (Seconds) | Total startup time (Seconds) 
 --- | --- | --- | --- |--- |--- 
-No CRaC | - | ... | - | 13 | 13
-CRaC - Container image | 187 | ... | - | 0.3 | 0.3
-CRaC - EFS | 187 | ... | - | 1.9 | 1.9
-CRaC - S3 CLI | 187 | 433.04 | 6.5 | 0.3 | 6.8
+No CRaC | - | ... | - | 9.353 | 9.353
+CRaC - Container image | 167.6 | ... | - | 0.344 | 0.344
+CRaC - EFS | 167.6 | ... | - | 1.013 | 1.013
+CRaC - S3 CLI | 167.6 | ... | 2.72 | 0.368 | 3.088
 
 The results for the implementation that is based on Spring Boot native integration with CRaC are as follows:
 Deployment | Checkpoint files size (MB) | Image size on ECR (MB) | Time to download Checkpoint files (Seconds) | Startup time (Seconds) | Total startup time (Seconds) 

--- a/README.md
+++ b/README.md
@@ -278,10 +278,10 @@ CRaC - S3 CLI | 187 | 433.04 | 6.5 | 0.3 | 6.8
 The results for the implementation that is based on Spring Boot native integration with CRaC are as follows:
 Deployment | Checkpoint files size (MB) | Image size on ECR (MB) | Time to download Checkpoint files (Seconds) | Startup time (Seconds) | Total startup time (Seconds) 
 --- | --- | --- | --- |--- |--- 
-No CRaC | - | ... | - | 19 | 19
-CRaC - Container image | 173 | ... | - | 2.5 | 2.5
-CRaC - EFS | 173 | ... | - | 4.2 | 4.2
-CRaC - S3 CLI | 173 | 471.90 | 7.5 | 2.5 | 10
+No CRaC | - | ... | - | 10.696 | 10.696
+CRaC - Container image | 157.9 | ... | - | 0.736 | 0.736
+CRaC - EFS | 157.9 | ... | - | 1.826 | 1.826
+CRaC - S3 CLI | 157.9 | ... | 3.265 | 0.643 | 3.908
 
 **NOTE:** The reduction in start-up time in case of Spring Boot native integration with CRaC is lower compared to the general approach; one of the reasons behind that is the captured checkpoint in case of Spring Boot native integration with CRaC only covers the Spring Boot framework, not the application.
 

--- a/examples/cmn/codebuild/buildspec.yml
+++ b/examples/cmn/codebuild/buildspec.yml
@@ -17,7 +17,7 @@ phases:
       - export CI_AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
       - export CI_AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
       - mkdir crac-files
-      - docker run --privileged --env AWS_REGION=$AWS_DEFAULT_REGION --env AWS_ACCESS_KEY_ID=$CI_AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$CI_AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN=$CI_AWS_SESSION_TOKEN --env SRVC_JAR_FILE_NAME=$SRVC_JAR_FILE_NAME --env MODE=ci --env AMAZON_DYNAMO_DB_ENDPOINT=https://dynamodb.$AWS_DEFAULT_REGION.amazonaws.com -v $PWD/crac-files:/opt/crac-files --rm --name $SRVC_NAME $SRVC_NAME:wo-checkpoint /opt/scripts/checkpoint.sh
+      - docker run --env AWS_REGION=$AWS_DEFAULT_REGION --env AWS_ACCESS_KEY_ID=$CI_AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$CI_AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN=$CI_AWS_SESSION_TOKEN --env SRVC_JAR_FILE_NAME=$SRVC_JAR_FILE_NAME --env MODE=ci --env AMAZON_DYNAMO_DB_ENDPOINT=https://dynamodb.$AWS_DEFAULT_REGION.amazonaws.com -v $PWD/crac-files:/opt/crac-files --rm --name $SRVC_NAME $SRVC_NAME:wo-checkpoint /opt/scripts/checkpoint.sh
       - aws s3 sync crac-files s3://$CRAC_CHECKPOINTS_BUCKET/$SRVC_NAME/v$CODEBUILD_BUILD_NUMBER/
       - echo $CODEBUILD_CRAC_CHECKPOINTS_EFS	
       - mkdir -p $CODEBUILD_CRAC_CHECKPOINTS_EFS/$SRVC_NAME/v$CODEBUILD_BUILD_NUMBER

--- a/examples/cmn/dockerfiles/Dockerfile_Build
+++ b/examples/cmn/dockerfiles/Dockerfile_Build
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:17-jdk-crac as builder
+FROM azul/zulu-openjdk:23.0.1-jdk-crac as builder
 
 COPY ./pom.xml ./pom.xml
 COPY src ./src/
@@ -14,7 +14,7 @@ RUN apt-get --fix-missing -qq update \
        sdk install maven > /dev/null 2>&1; \
        mvn --no-transfer-progress -Dmaven.test.skip=true clean package"
 
-FROM azul/zulu-openjdk:17-jdk-crac
+FROM azul/zulu-openjdk:23.0.1-jdk-crac
 
 RUN apt-get --fix-missing -qq update \
     && apt-get -qq -y install zip curl > /dev/null \

--- a/examples/cmn/k8s/springdemo/deployment-crac-efs-mount.yaml
+++ b/examples/cmn/k8s/springdemo/deployment-crac-efs-mount.yaml
@@ -28,14 +28,6 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-        securityContext:
-          capabilities:
-            add:
-              - CHECKPOINT_RESTORE
-              - SYS_PTRACE
-          privileged: false
-          runAsUser: 0
-          allowPrivilegeEscalation: false
         command: ["/bin/bash"]
         args: ["/opt/scripts/run-service-crac.sh"]
         envFrom:

--- a/examples/cmn/k8s/springdemo/deployment-crac-s3-cli.yaml
+++ b/examples/cmn/k8s/springdemo/deployment-crac-s3-cli.yaml
@@ -21,14 +21,6 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-        securityContext:
-          capabilities:
-            add:
-              - CHECKPOINT_RESTORE
-              - SYS_PTRACE
-          privileged: false
-          runAsUser: 0
-          allowPrivilegeEscalation: false
         command: ["/bin/bash"]
         args: ["/opt/scripts/run-service-crac-s3.sh"]
         envFrom:

--- a/examples/cmn/k8s/springdemo/deployment-crac.yaml
+++ b/examples/cmn/k8s/springdemo/deployment-crac.yaml
@@ -27,14 +27,6 @@ spec:
         env:
         - name: CRAC_CHECKPOINT_PATH
           value: /opt/crac-files
-        securityContext:
-          capabilities:
-            add:
-              - CHECKPOINT_RESTORE
-              - SYS_PTRACE
-          privileged: false
-          runAsUser: 0
-          allowPrivilegeEscalation: false
         command: ["/bin/bash"]
         args: ["/opt/scripts/run-service-crac.sh"]
         readinessProbe:

--- a/examples/springdemo-native-int/code/pom.xml
+++ b/examples/springdemo-native-int/code/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.2</version>
+		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.amazon</groupId>
@@ -14,7 +14,7 @@
 	<name>CustomerService</name>
 	<description>Demo application to demonstrate steps for reducing startup time for Spring Boot app using CRaC</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>23</java.version>
 		<aws.sdk.version>2.20.68</aws.sdk.version>
 	</properties>
 	<dependencies>
@@ -85,6 +85,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>1.18.36</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -110,6 +111,15 @@
 
 	<build>
 		<plugins>
+			<plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-compiler-plugin</artifactId>
+		        <configuration>
+		            <compilerArgs>
+		                <arg>-proc:full</arg>
+		            </compilerArgs>
+		        </configuration>
+		    </plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/examples/springdemo-native-int/scripts/checkpoint.sh
+++ b/examples/springdemo-native-int/scripts/checkpoint.sh
@@ -8,7 +8,7 @@ rm -rf /opt/crac-files/*
 echo Starting the application...
 ( echo 128 > /proc/sys/kernel/ns_last_pid ) 2>/dev/null || while [ $(cat /proc/sys/kernel/ns_last_pid) -lt 128 ]; do :; done;
 TABLE_NAME=springdemo-native-int-staging-customer
-java -Dspring.context.checkpoint=onRefresh -Dtable.name=${TABLE_NAME} -Dspring.profiles.active=prod -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -Djdk.crac.collect-fd-stacktraces=true -XX:CRaCCheckpointTo=/opt/crac-files/ -jar /${SRVC_JAR_FILE_NAME}
+java -Dspring.context.checkpoint=onRefresh -Dtable.name=${TABLE_NAME} -Dspring.profiles.active=prod -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -Djdk.crac.collect-fd-stacktraces=true -XX:CRaCEngine=warp -XX:CRaCCheckpointTo=/opt/crac-files/ -jar /${SRVC_JAR_FILE_NAME}
 
 EXIT_CODE=$?
 

--- a/examples/springdemo-native-int/scripts/run-service-crac.sh
+++ b/examples/springdemo-native-int/scripts/run-service-crac.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # run java
 echo 'Start time: '$(date +"%T.%3N")
-java -XX:CRaCRestoreFrom=${CRAC_CHECKPOINT_PATH} -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -Daws.webIdentityTokenFile="${AWS_WEB_IDENTITY_TOKEN_FILE}" -Daws.roleArn="${AWS_ROLE_ARN}" 
+java -XX:CRaCEngine=warp -XX:CRaCRestoreFrom=${CRAC_CHECKPOINT_PATH} -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -Daws.webIdentityTokenFile="${AWS_WEB_IDENTITY_TOKEN_FILE}" -Daws.roleArn="${AWS_ROLE_ARN}" 
 
 # the code below is to keep the container running if the java process failed 
 echo Executing an infinite loop to keep the container running...

--- a/examples/springdemo-native-int/scripts/run-service.sh
+++ b/examples/springdemo-native-int/scripts/run-service.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 # run java
 echo Starting the application...
-java -Dspring.profiles.active=prod -Dmode=${MODE} -Dtable.name=${TABLE_NAME} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -XX:CRaCCheckpointTo=/opt/crac-files -jar /${SRVC_JAR_FILE_NAME}
+java -Dspring.profiles.active=prod -Dmode=${MODE} -Dtable.name=${TABLE_NAME} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -jar /${SRVC_JAR_FILE_NAME}

--- a/examples/springdemo/code/pom.xml
+++ b/examples/springdemo/code/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.1</version>
+		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.amazon</groupId>
@@ -14,20 +14,20 @@
 	<name>CustomerService</name>
 	<description>Demo application to demonstrate steps for reducing startup time for Spring Boot app using CRaC</description>
 	<properties>
-		<java.version>17</java.version>
-		<tomcat.version>10.1.7</tomcat.version>
-		<aws.sdk.version>2.19.7</aws.sdk.version>
+		<java.version>23</java.version>
+		<aws.sdk.version>2.20.68</aws.sdk.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>io.github.crac.org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-core</artifactId>
-			<version>10.1.7</version>
-		</dependency>
 		<dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${aws.sdk.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -53,8 +53,8 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 			<exclusions>
 				<exclusion>
-					<groupId>org.apache.tomcat.embed</groupId>
-					<artifactId>tomcat-embed-core</artifactId>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -85,6 +85,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>1.18.36</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -94,7 +95,7 @@
 		<dependency>
 			<groupId>org.crac</groupId>
 			<artifactId>crac</artifactId>
-			<version>0.1.3</version>
+			<version>1.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.kubernetes</groupId>
@@ -106,11 +107,19 @@
 			<artifactId>client-java-api</artifactId>
 			<version>13.0.0</version>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-compiler-plugin</artifactId>
+		        <configuration>
+		            <compilerArgs>
+		                <arg>-proc:full</arg>
+		            </compilerArgs>
+		        </configuration>
+		    </plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/examples/springdemo/scripts/checkpoint.sh
+++ b/examples/springdemo/scripts/checkpoint.sh
@@ -4,7 +4,7 @@
 echo Starting the application...
 ( echo 128 > /proc/sys/kernel/ns_last_pid ) 2>/dev/null || while [ $(cat /proc/sys/kernel/ns_last_pid) -lt 128 ]; do :; done;
 TABLE_NAME=springdemo-staging-customer
-nohup java -Dspring.profiles.active=prod -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -XX:CRaCCheckpointTo=/opt/crac-files -jar /${SRVC_JAR_FILE_NAME} &
+nohup java -Dspring.profiles.active=prod -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -XX:CRaCEngine=warp -XX:CRaCCheckpointTo=/opt/crac-files -jar /${SRVC_JAR_FILE_NAME} &
 
 # ensure the application started successfully
 echo Confirming the application started successfully...
@@ -18,14 +18,15 @@ curl http://localhost:8080/api/customers
 # request a checkpoint
 echo Taking a snapshot of the application using CRaC...
 mkdir /opt/logs/
+jcmd ${SRVC_JAR_FILE_NAME} JDK.checkpoint >> /opt/logs/snapshot.log
+sleep 10
+
 # Waiting till the checkpoint is captured correctly
 i=0
-
 while [[ $i -lt 10 ]]
 do
   echo Waiting till the checkpoint is captured correctly...
-  jcmd ${SRVC_JAR_FILE_NAME} JDK.checkpoint >> /opt/logs/snapshot.log
-  if ([ -f /opt/crac-files/dump4.log ]) && (grep -Fq "Dumping finished successfully" "/opt/crac-files/dump4.log")
+  if ([ -f /opt/crac-files/core.img ])
   then
     echo Checkpoint captured!
     exit 0

--- a/examples/springdemo/scripts/run-service-crac.sh
+++ b/examples/springdemo/scripts/run-service-crac.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # run java
 echo 'Start time: '$(date +"%T.%3N")
-java -XX:CRaCRestoreFrom=${CRAC_CHECKPOINT_PATH} -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -Daws.webIdentityTokenFile="${AWS_WEB_IDENTITY_TOKEN_FILE}" -Daws.roleArn="${AWS_ROLE_ARN}" 
+java -XX:CRaCEngine=warp -XX:CRaCRestoreFrom=${CRAC_CHECKPOINT_PATH} -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -Daws.webIdentityTokenFile="${AWS_WEB_IDENTITY_TOKEN_FILE}" -Daws.roleArn="${AWS_ROLE_ARN}" 
 
 # the code below is to keep the container running if the java process failed 
 echo Executing an infinite loop to keep the container running...

--- a/examples/springdemo/scripts/run-service.sh
+++ b/examples/springdemo/scripts/run-service.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 # run java
 echo Starting the application...
-java -Dspring.profiles.active=prod -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -XX:CRaCCheckpointTo=/opt/crac-files -jar /${SRVC_JAR_FILE_NAME}
+java -Dspring.profiles.active=prod -Dtable.name=${TABLE_NAME} -Dmode=${MODE} -Damazon.dynamodb.endpoint=${AMAZON_DYNAMO_DB_ENDPOINT} -jar /${SRVC_JAR_FILE_NAME}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-eks-crac/issues/19

*Description of changes:*
Update the sample implementation to use Warp as checkpoint/restore (C/R) engine. This involves the following changes:
1. Upgrade to JDK 23
2. Add the required command parameters to use Warp rather than CRIU as C/R engine
3. Remove Linux capabilities that were earlier granted to pods
4. Stop running docker in privileged move in the build process

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
